### PR TITLE
adds crossorigin attribute to fonts preload

### DIFF
--- a/themes/console-home/layouts/partials/head.html
+++ b/themes/console-home/layouts/partials/head.html
@@ -4,12 +4,12 @@
     <meta name="description" content="{{ .Summary }}" />
 
     <link rel="stylesheet" href="/css/normalize.css" />
-    <link rel="preload" href="/fonts/rubik-v12-latin-regular.woff2" as="font">
-    <link rel="preload" href="/fonts/rubik-v12-latin-italic.woff2" as="font">
-    <link rel="preload" href="/fonts/rubik-v12-latin-300.woff2" as="font">
-    <link rel="preload" href="/fonts/rubik-v12-latin-300italic.woff2" as="font">
-    <link rel="preload" href="/fonts/rubik-v12-latin-500.woff2" as="font">
-    <link rel="preload" href="/fonts/rubik-v12-latin-500italic.woff2" as="font">
+    <link rel="preload" href="/fonts/rubik-v12-latin-regular.woff2" as="font" crossorigin="anonymous">
+    <link rel="preload" href="/fonts/rubik-v12-latin-italic.woff2" as="font" crossorigin="anonymous">
+    <link rel="preload" href="/fonts/rubik-v12-latin-300.woff2" as="font" crossorigin="anonymous">
+    <link rel="preload" href="/fonts/rubik-v12-latin-300italic.woff2" as="font" crossorigin="anonymous">
+    <link rel="preload" href="/fonts/rubik-v12-latin-500.woff2" as="font" crossorigin="anonymous">
+    <link rel="preload" href="/fonts/rubik-v12-latin-500italic.woff2" as="font" crossorigin="anonymous">
     <link rel="stylesheet" href="/css/fonts.css" />
     <link rel="stylesheet" href="/css/vars.css" />
     <link rel="preload" href="/css/style-dark.css" as="style" />


### PR DESCRIPTION
Fixes font preload not being used by Chrome due to missing `crossorigin` attribute
https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content#cors-enabled_fetches

The warnings:
![image](https://user-images.githubusercontent.com/632296/115535501-17ec7300-a299-11eb-8491-b18fd3598a9a.png)
