### PR TITLE
fixes planet animation

### DIFF
--- a/themes/console-home/layouts/partials/components/research/mars/shared/the-earth.html
+++ b/themes/console-home/layouts/partials/components/research/mars/shared/the-earth.html
@@ -1,4 +1,4 @@
 <div class="mars-illustration-earth{{ with .isLarge }} is-large{{ end }}">
     <div class="mars-illustration-earth-inner-shading"></div>
-    <div class="mars-illustration-earth-texture"></div>
+    <div class="mars-illustration-earth-texture"><div><span></span><span></span></div></div>
 </div>

--- a/themes/console-home/layouts/partials/components/research/mars/shared/the-mars.html
+++ b/themes/console-home/layouts/partials/components/research/mars/shared/the-mars.html
@@ -1,4 +1,4 @@
 <div class="mars-illustration-mars{{ with .isLarge }} is-large{{ end }}">
     <div class="mars-illustration-mars-inner-shading"></div>
-    <div class="mars-illustration-mars-texture"></div>
+    <div class="mars-illustration-mars-texture"><div><span></span><span></span></div></div>
 </div>

--- a/themes/console-home/static/css/page/research/mars.css
+++ b/themes/console-home/static/css/page/research/mars.css
@@ -206,11 +206,17 @@ html {
     height: 100%;
     top: 0;
     left: 0;
-    background-image: var(--theme-mars-earth-texture);
-    background-size: auto 100%;
-    background-position: 41.42% 0;
+    overflow: hidden;
     z-index: 10;
+}
 
+.mars-illustration-earth-texture div {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 400%;
+    height: 100%;
+    transform: translateX(-60.4%);
     animation-name: rotate-earth;
     animation-duration: 20s;
     animation-delay: 0s;
@@ -221,16 +227,38 @@ html {
 
 @keyframes rotate-earth {
     0% {
-        background-position: 41.42% 0;
+        transform: translateX(-60.4%);
     }
     100% {
-        background-position: -158.58% 0;
+        transform: translateX(-10.4%);
     }
 }
 
-.is-large .mars-illustration-earth-texture {
-    background-image: url("/img/research/mars/earth-texture-large.png");
+.mars-illustration-earth-texture span:first-child,
+.mars-illustration-earth-texture span:last-child {
+    position: absolute;
+    top: 0;
+    height: 100%;
+    width: 50%;
+    background-image: var(--theme-mars-earth-texture);
+    background-size: auto 100%;
+}
+
+.mars-illustration-earth-texture span:first-child {
+    left: 0;
+}
+
+.mars-illustration-earth-texture span:last-child {
+    left: 50%;
+}
+
+.is-large .mars-illustration-earth-texture div {
     animation-duration: 30s;
+}
+
+.is-large .mars-illustration-earth-texture span:first-child,
+.is-large .mars-illustration-earth-texture span:last-child {
+    background-image: url("/img/research/mars/earth-texture-large.png");
 }
 
 .mars-illustration-mars {
@@ -263,12 +291,18 @@ html {
     height: 100%;
     top: 0;
     left: 0;
-    background-image: var(--theme-mars-mars-texture);
-    background-size: auto 100%;
-    background-position: 0 0;
+    overflow: hidden;
     z-index: 10;
+}
 
-    animation-name: rotate-earth;
+.mars-illustration-mars-texture div {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 400%;
+    height: 100%;
+    transform: translateX(-50%);
+    animation-name: rotate-mars;
     animation-duration: calc(20s * 1.026);
     animation-delay: 0s;
     animation-timing-function: linear;
@@ -276,18 +310,40 @@ html {
     animation-fill-mode: forwards;
 }
 
-@keyframes rotate-earth {
+@keyframes rotate-mars {
     0% {
-        background-position: 0 0;
+        transform: translateX(-50%);
     }
     100% {
-        background-position: -200% 0;
+        transform: translateX(-0%);
     }
 }
 
-.is-large .mars-illustration-mars-texture {
-    background-image: url("/img/research/mars/mars-texture-large.png");
+.mars-illustration-mars-texture span:first-child,
+.mars-illustration-mars-texture span:last-child {
+    position: absolute;
+    top: 0;
+    height: 100%;
+    width: 50%;
+    background-image: var(--theme-mars-mars-texture);
+    background-size: auto 100%;
+}
+
+.mars-illustration-mars-texture span:first-child {
+    left: 0;
+}
+
+.mars-illustration-mars-texture span:last-child {
+    left: 50%;
+}
+
+.is-large .mars-illustration-mars-texture div {
     animation-duration: calc(30s * 1.026);
+}
+
+.is-large .mars-illustration-mars-texture span:first-child,
+.is-large .mars-illustration-mars-texture span:last-child {
+    background-image: url("/img/research/mars/mars-texture-large.png");
 }
 
 /* Artwork
@@ -1671,6 +1727,9 @@ html {
 
 .space-networks .mars-illustration-earth-texture {
     opacity: 0.22;
+}
+
+.space-networks .mars-illustration-earth-texture div {
     animation: none;
 }
 
@@ -1728,6 +1787,9 @@ html {
 
 .space-networks .mars-illustration-mars-texture {
     opacity: 0.3;
+}
+
+.space-networks .mars-illustration-mars-texture div {
     animation: none;
 }
 


### PR DESCRIPTION
I've refactored the animation to use translation and avoid animating the "background" property, ideally this should fix the issue with planets texture not appearing. Worth mentioning that production is continuously reloading these images when animating:
![image](https://user-images.githubusercontent.com/632296/121198443-6cac7300-c872-11eb-95e2-e4a3d73490e4.png)

This should fix that as well, can't be 100% sure as it's not happening locally.
﻿