### PR TITLE
fixes link appearance on light theme

### DIFF
--- a/themes/console-home/static/css/components.css
+++ b/themes/console-home/static/css/components.css
@@ -243,7 +243,7 @@
    ================================================================================================================ */
 .link:link,
 .link:visited {
-    color: var(--theme-text-1);
+    color: var(--theme-link-text-idle);
     text-decoration: underline;
     font-weight: 400;
     transition: var(--a-controls);
@@ -256,19 +256,19 @@
 
 .link:hover,
 .link:focus {
-    color: var(--c-blue-04);
+    color: var(--theme-link-text-focus);
     text-decoration: none;
 }
 
 .link:active {
-    color: var(--c-blue-06-main);
+    color: var(--theme-link-text-active);
     text-decoration: none;
     transition: var(--a-controls-active);
 }
 
 .link:link .icon,
 .link:visited .icon {
-    fill: var(--theme-text-1);
+    fill: var(--theme-link-text-idle);
     transition: var(--a-controls);
     vertical-align: -0.2em;
     width: 1em;
@@ -277,11 +277,11 @@
 
 .link:hover .icon,
 .link:focus .icon {
-    fill: var(--c-blue-04);
+    fill: var(--theme-link-text-focus);
 }
 
 .link:active .icon {
-    fill: var(--c-blue-06-main);
+    fill: var(--theme-link-text-active);
     transition: var(--a-controls-active);
 }
 

--- a/themes/console-home/static/css/style-dark.css
+++ b/themes/console-home/static/css/style-dark.css
@@ -50,6 +50,10 @@
     --theme-input-bg: var(--c-white-00-absolute);
     --theme-input-border: transparent;
 
+    --theme-link-text-idle: var(--theme-text-1);
+    --theme-link-text-focus: var(--c-blue-04);
+    --theme-link-text-active: var(--c-blue-06-main);
+
     --theme-nav-primary-link-text-idle: var(--c-white-00-absolute);
     --theme-nav-primary-link-text-focus: var(--c-blue-04);
     --theme-nav-primary-link-text-active: var(--c-blue-06-main);

--- a/themes/console-home/static/css/style-light.css
+++ b/themes/console-home/static/css/style-light.css
@@ -50,6 +50,10 @@
     --theme-input-bg: var(--c-white-00-absolute);
     --theme-input-border: rgba(0, 0, 0, 0.2);
 
+    --theme-link-text-idle: var(--theme-text-1);
+    --theme-link-text-focus: var(--c-blue-06-main);
+    --theme-link-text-active: var(--c-blue-08);
+
     --theme-nav-primary-link-text-idle: var(--c-black-02-main);
     --theme-nav-primary-link-text-focus: var(--c-blue-06-main);
     --theme-nav-primary-link-text-active: var(--c-blue-08);


### PR DESCRIPTION
Fixes link appearance on light theme.

See [issue](https://3.basecamp.com/4477159/buckets/19757286/todos/3736414819) and [correct design](https://www.figma.com/file/AWLQPkrIq7Bgv3a6uGLIMg/%E2%98%89-Console-Library?node-id=214%3A829).