### PR TITLE
Spacing tweaks

### DIFF
--- a/themes/console-home/layouts/tools/list.html
+++ b/themes/console-home/layouts/tools/list.html
@@ -99,7 +99,6 @@
 				{{ $categoryData := (dict "category" "devops" "subcategory" (dict "label" "Server monitoring" "name" "server-monitoring")) }}
 				{{ partial "components/category.html" (dict "categoryData" $categoryData "clickable" "true" "large" "true" )  }}
 			</div>
-			<br />
 			<div class="category-reviews-item">
 				{{ $categoryData := (dict "category" "devops" "subcategory" (dict "label" "Website / synthetic monitoring" "name" "website-synthetic-monitoring")) }}
 				{{ partial "components/category.html" (dict "categoryData" $categoryData "clickable" "true" "large" "true" )  }}


### PR DESCRIPTION
Adjusts the spacing of category review items in the tools list.

From this:
![image](https://user-images.githubusercontent.com/632296/131546734-1dfb2e7b-a5a6-4cdd-8171-a7ac1086be3e.png)


To this:
![image](https://user-images.githubusercontent.com/632296/131546691-999118dd-bfea-4b8d-a7b7-ef9da8b95a30.png)
