### PR TITLE
Fixes ios15 popup navigation

### DIFF
--- a/themes/console-home/static/css/styles.css
+++ b/themes/console-home/static/css/styles.css
@@ -364,6 +364,7 @@ body.show-planes:after {
     width: 100%;
     min-height: 100%;
     overflow-x: hidden;
+    z-index: 30;
 }
 
 .content {


### PR DESCRIPTION
@davidmytton DevTools access on BrowserStack is not seamless so I wasn't able to debug the issue perfectly.

However this should provide a fix for #119 nonetheless.