### PR TITLE
Fixes TOC positioning

### DIFF
--- a/content/browser-testing/browserstack.md
+++ b/content/browser-testing/browserstack.md
@@ -205,6 +205,8 @@ BrowserStack’s functionality and use it in a variety of scenarios.
 
 {{< a--close >}}
 
+{{< div--close >}}
+
 {{< nav-wrapper--open id="wrapper-3" anchor-name="dislike" >}}
 
 {{< rich-title-3 icon="dislike" >}}What we don't like{{</ rich-title-3 >}}
@@ -250,6 +252,8 @@ solutions by presenting the results in a more user friendly fashion.
 {{< img-custom class="content-image" src="/img/browser-testing/browserstack-webtesting.png" alt="Screenshot of web testing with BrowserStack." >}}
 
 {{< a--close >}}
+
+{{< div--close >}}
 
 {{< nav-wrapper--open id="wrapper-4" anchor-name="console-developer-perspective" >}}
 

--- a/content/browser-testing/ghost-inspector.md
+++ b/content/browser-testing/ghost-inspector.md
@@ -316,3 +316,5 @@ table below.
 {{< div--close >}}
 
 {{< nav-wrapper--open id="wrapper-8" anchor-name="related-articles" >}}
+
+{{< div--close >}}

--- a/content/browser-testing/sauce-labs.md
+++ b/content/browser-testing/sauce-labs.md
@@ -338,3 +338,5 @@ table below.
 {{< div--close >}}
 
 {{< nav-wrapper--open id="wrapper-8" anchor-name="related-articles" >}}
+
+{{< div--close >}}

--- a/content/browser-testing/selenium.md
+++ b/content/browser-testing/selenium.md
@@ -337,3 +337,5 @@ table below.
 {{< div--close >}}
 
 {{< nav-wrapper--open id="wrapper-8" anchor-name="related-articles" >}}
+
+{{< div--close >}}

--- a/content/code-collaboration-pair-programming/_index.md
+++ b/content/code-collaboration-pair-programming/_index.md
@@ -140,6 +140,8 @@ allow the host to grant and revoke permissions to each individual participant.
 
 {{< div--close >}}
 
+{{< div--close >}}
+
 ### Best code collaboration tools
 
 We reviewed 10 online code collaboration tools. The best is: CodeTogether. We

--- a/content/load-testing/_index.md
+++ b/content/load-testing/_index.md
@@ -44,9 +44,9 @@ large spike of traffic and how fast pages load. The best load testing tools
 provide scriptable test plans, protocol- and browser-level test execution, and
 for this review must also have a developer focus.
 
-We tested 11 load testing tools using our independent [selection
-criteria](/selection-criteria/) and the requirements described below. The best 6
-load testing tools for developers and engineers in {{< year >}} are:
+We tested 11 load testing tools using our independent
+[selection criteria](/selection-criteria/) and the requirements described below.
+The best 6 load testing tools for developers and engineers in {{< year >}} are:
 
 1. [Flood](#flood)
 2. [k6](#k6)
@@ -116,6 +116,8 @@ regression testing, a CLI and a nicely designed dark mode if there is a GUI.
 We reviewed 11 load testing tools. The best is: [Flood](#flood). We also liked
 [k6](#k6) and [Locust](#locust).
 
+{{< div--close >}}
+
 {{< nav-wrapper--open anchor-name="flood" >}}
 
 ### Flood
@@ -163,6 +165,8 @@ different scripting frameworks as well as the control it offers over the
 infrastructure. As a developer, I appreciate the cross-platform/framework
 approach because it allows you to define all your test plans in code, which is
 where they should be.
+
+{{< div--close >}}
 
 {{< nav-wrapper--open anchor-name="k6" >}}
 
@@ -218,6 +222,8 @@ If you are looking just for HTTP load testing then k6 does a great job, but the
 main limitation is the lack of browser simulation. If you want to test browser
 rendering performance, k6 is not the right tool.
 
+{{< div--close >}}
+
 {{< nav-wrapper--open anchor-name="locust" >}}
 
 ### Locust
@@ -250,6 +256,8 @@ Locust displays its results in a simple web UI but they can also be exported as
 CSV, or direct to the terminal if executed as a CLI. If you don’t like
 Javascript, Java or Scala, Locust is a good alternative to k6, JMeter or
 Gatling.
+
+{{< div--close >}}
 
 {{< nav-wrapper--open anchor-name="loadster" >}}
 
@@ -287,6 +295,8 @@ The main complaint against Loadster is the lack of scripting capabilities, but
 that is somewhat made up for by the advanced options available for both protocol
 and browser testing. It is clearly designed for technical users.
 
+{{< div--close >}}
+
 {{< nav-wrapper--open anchor-name="gatling" >}}
 
 ### Gatling
@@ -322,6 +332,8 @@ Gatling is a very flexible load testing tool framework that benefits from the
 power of using Scala for test plans. However, its reliance on Java means
 installation is a pain for developers on their desktop, especially if on macOS
 which blocks Java scripts by default.
+
+{{< div--close >}}
 
 {{< nav-wrapper--open anchor-name="apache-jmeter" >}}
 
@@ -364,6 +376,8 @@ into other testing products. JMeter was once the first choice for developers -
 and is still a good, open source load testing framework - but there are now good
 quality JMeter alternatives that can provide a more modern approach.
 
+{{< div--close >}}
+
 {{< nav-wrapper--open anchor-name="loadview" >}}
 
 ### LoadView
@@ -399,6 +413,8 @@ recording and editing test scripts in code, but only using
 Tests must also be run through the UI or triggered via the API, so integration
 into CI/CD pipelines is limited.
 
+{{< div--close >}}
+
 {{< nav-wrapper--open anchor-name="siege" >}}
 
 ### Siege
@@ -427,6 +443,8 @@ numbers of simultaneous requests. This is good for testing whether your
 infrastructure can suddenly scale up, but does not represent what real users
 will do. Siege is useful for quick testing, but the other tools reviewed have
 many more capabilities.
+
+{{< div--close >}}
 
 {{< nav-wrapper--open anchor-name="bees-with-machine-guns" >}}
 
@@ -468,6 +486,8 @@ lacks advanced scripting and reporting, so is probably best used as a simple
 ad-hoc test utility. It does have a cool name though. The status outputs are
 quite fun.
 
+{{< div--close >}}
+
 {{< nav-wrapper--open anchor-name="loadninja" >}}
 
 ### LoadNinja
@@ -502,6 +522,8 @@ LoadNinja can be triggered by CI/CD integration into Jenkins, but does not
 support any other systems unless you write your own scripts to trigger runs via
 their API. The scriptless approach means it can be managed by non-technical
 users but it lacks advanced features.
+
+{{< div--close >}}
 
 {{< nav-wrapper--open anchor-name="neoload" >}}
 
@@ -540,8 +562,7 @@ CI/CD systems easily. There are much better load testing tools for developers.
 
 ### Also considered
 
-- [Silk
-  Performer](https://www.microfocus.com/en-us/products/silk-performer/overview)
+- [Silk Performer](https://www.microfocus.com/en-us/products/silk-performer/overview)
   we were not able to test because it required contacting sales to request a
   free trial. The [Console selection criteria](/selection-criteria/) require
   that tools be available as self-service, so we excluded it from this review.
@@ -563,6 +584,8 @@ CI/CD systems easily. There are much better load testing tools for developers.
   [Console selection criteria](/selection-criteria/) require that tools be
   available as self-service, so we excluded it from this review.
 
+{{< div--close >}}
+
 {{< nav-wrapper--open anchor-name="editorial-policy" >}}
 
 ### Our editorial policy
@@ -570,8 +593,8 @@ CI/CD systems easily. There are much better load testing tools for developers.
 #### Why you can trust us
 
 Console is written by developers for developers. Using our decades of experience
-building software at scale, we apply strict [selection
-criteria](/selection-criteria/) to decide which software we feature.
+building software at scale, we apply strict
+[selection criteria](/selection-criteria/) to decide which software we feature.
 
 This includes asking questions like "Would this form part of a daily-use set of
 developer tools?", "Would this be used by advanced, power-users?" and "Does it
@@ -581,3 +604,5 @@ to be featured.
 
 We **do not** accept payment for inclusion and where we work with partners, they
 must fit our selection criteria before we consider working with them.
+
+{{< div--close >}}

--- a/content/server-monitoring/_index.md
+++ b/content/server-monitoring/_index.md
@@ -579,8 +579,6 @@ it?
 
 {{< div--close >}}
 
-{{< nav-wrapper--open anchor-name="hosted-saas-also-considered" >}}
-
 #### Also considered: Dynatrace, Logic Monitor + 2 more
 
 These are the other hosted SaaS server monitoring services we tested. They are
@@ -684,8 +682,6 @@ you to
 Datadog, Prometheus, AWS, Google Cloud or OpenTelemetry. As such, we decided not
 to review it as part of this article on server monitoring. It will be covered in
 a future Console review of tracing and observability tools.
-
-{{< div--close >}}
 
 {{< div--close >}}
 
@@ -1117,8 +1113,6 @@ major limitation.
 
 {{< div--close >}}
 
-{{< nav-wrapper--open anchor-name="self-hosted-also-considered" >}}
-
 #### Also considered: 8 more
 
 These are the other server monitoring tools we tested. They are not as highly
@@ -1356,17 +1350,15 @@ our two finalists above.
 
 {{< div--close >}}
 
-{{< div--close >}}
-
 ### FAQ
 
 {{< category-review/faq category="server-monitoring" >}}
 
-{{< nav-wrapper--open id="wrapper-10" anchor-name="editorial-policy" >}}
-
 ### Related categories
 
 {{< category-review/related-categories >}}
+
+{{< nav-wrapper--open id="wrapper-10" anchor-name="editorial-policy" >}}
 
 ### Our editorial policy
 

--- a/content/website-monitoring/_index.md
+++ b/content/website-monitoring/_index.md
@@ -1216,6 +1216,8 @@ technical users.
 
 We also tested the following 6 tools but they did not meet our criteria:
 
+{{< div--close >}}
+
 {{< nav-wrapper--open anchor-name="alertra" >}}
 
 {{< category-review/card-heading name="Alertra" anchor="alertra" thumbnail="/img/favicons/www.alertra.com.jpg" url="https://www.alertra.com" score="none" >}}
@@ -1368,11 +1370,11 @@ As such, we do not recommend UptimeRobot for developers.
 
 {{< category-review/faq category="website-monitoring" >}}
 
-{{< nav-wrapper--open id="wrapper-10" anchor-name="editorial-policy" >}}
-
 ### Related categories
 
 {{< category-review/related-categories >}}
+
+{{< nav-wrapper--open id="wrapper-10" anchor-name="editorial-policy" >}}
 
 ### Our editorial policy
 

--- a/themes/console-home/static/js/category-review.js
+++ b/themes/console-home/static/js/category-review.js
@@ -34,7 +34,7 @@ let computeTOCPos = (() => {
         if (diff < 0) {
             style.position = "fixed";
             style.top = midPoint - TOCHeightHalf + "px";
-            if (reachedBottom) {
+            if (reachedBottom || lastBlock.getBoundingClientRect().top < 0) {
                 let pos = midPoint - TOCHeightHalf + lastBlock.getBoundingClientRect().top;
                 style.top = pos + "px";
             }

--- a/themes/console-home/static/js/research/mars.js
+++ b/themes/console-home/static/js/research/mars.js
@@ -34,7 +34,7 @@ let computeTOCPos = (() => {
         if (diff < 0) {
             style.position = "fixed";
             style.top = midPoint - TOCHeightHalf + "px";
-            if (reachedBottom) {
+            if (reachedBottom || lastBlock.getBoundingClientRect().top < 0) {
                 let pos = midPoint - TOCHeightHalf + lastBlock.getBoundingClientRect().top;
                 style.top = pos + "px";
             }

--- a/themes/console-home/static/js/vendor-review.js
+++ b/themes/console-home/static/js/vendor-review.js
@@ -34,7 +34,7 @@ let computeTOCPos = (() => {
         if (diff < 0) {
             style.position = "fixed";
             style.top = midPoint - TOCHeightHalf + "px";
-            if (reachedBottom) {
+            if (reachedBottom || lastBlock.getBoundingClientRect().top < 0) {
                 let pos = midPoint - TOCHeightHalf + lastBlock.getBoundingClientRect().top;
                 style.top = pos + "px";
             }


### PR DESCRIPTION
@davidmytton fixes the issue where the TOC would appear below its allowed position when the page loads with a given scroll position:

![image](https://user-images.githubusercontent.com/632296/146045400-5ef34b7a-da22-4f49-b294-799641751562.png)
