### PR TITLE
Fix load-testing page

### DIFF
--- a/content/load-testing/_index.md
+++ b/content/load-testing/_index.md
@@ -14,10 +14,8 @@ metaDescription:
 headerType: fixed
 hideLines: true
 hidePlanes: true
-type: tools
 layout: simple
-isPage: tools
-isSubpage: load-testing
+isPage: load-testing
 customStyle: false
 customPageStyle: false
 category: developer-tools


### PR DESCRIPTION
Fixes `/load-testing/` currrently broken live due to the wrong template being used.

@davidmytton you'll want to quick merge this.

![image](https://user-images.githubusercontent.com/632296/149959524-2a69ee55-88fb-4266-85a2-44fa3d14bfc2.png)
